### PR TITLE
Customization via chat commands support

### DIFF
--- a/FiveSecondRule.lua
+++ b/FiveSecondRule.lua
@@ -165,7 +165,7 @@ function FiveSecondRule:OnUpdate()
         -- Set manaTickText to display consumed mana in deep purple (hex color 800080)
         manaTickText:SetText(self:ManaLossText(manaUsed))
         manaTickText:SetAlpha(1)
-        manaTickText:Show()
+        if FiveSecondRule_Settings.showText then manaTickText:Show() end
 
         -- Uncomment for debugging if needed:
         -- DEFAULT_CHAT_FRAME:AddMessage("Mana used: -" .. manaUsed)
@@ -183,7 +183,7 @@ function FiveSecondRule:OnUpdate()
         -- Display observed gain as a positive number
         manaTickText:SetText(self:ManaGainText(observedGain))
         manaTickText:SetAlpha(1)
-        manaTickText:Show()
+        if FiveSecondRule_Settings.showText then manaTickText:Show() end
         self.manaTickTimer = now
         self.fadeTimer = now
 
@@ -214,7 +214,7 @@ function FiveSecondRule:OnEvent(event)
             local manaUsed = FiveSecondRule.previousMana - currentMana
             manaTickText:SetText(self:ManaLossText(manaUsed))
             manaTickText:SetAlpha(1)
-            manaTickText:Show()
+            if FiveSecondRule_Settings.showText then manaTickText:Show() end
             -- Uncomment for debugging if needed:
             -- DEFAULT_CHAT_FRAME:AddMessage("Mana used (event): -" .. manaUsed)
             FiveSecondRule.tickStartTime = nil

--- a/FiveSecondRule.toc
+++ b/FiveSecondRule.toc
@@ -4,6 +4,9 @@
 ## Author: StormtrooperTK421
 ## Notes: Five-second rule (FSR), mana tick (MP5), and mana gain tracking
 ## SavedVariables:
-## SavedVariablesPerCharacter:
+## SavedVariablesPerCharacter: FiveSecondRule_Settings
 
+FiveSecondRule_Utils.lua
+FiveSecondRule_Settings.lua
 FiveSecondRule.lua
+FiveSecondRule_Cmd.lua

--- a/FiveSecondRule_Cmd.lua
+++ b/FiveSecondRule_Cmd.lua
@@ -1,0 +1,108 @@
+FiveSecondRule_Cmd = {}
+FiveSecondRule_AddonName = "FiveSecondRule"
+
+SLASH_FIVESECONDRULE1 = "/fsr"
+SLASH_FIVESECONDRULE2 = "/fivesecondrule"
+
+-- print message on game load
+DEFAULT_CHAT_FRAME:AddMessage(FiveSecondRule_AddonName .. " loaded. Type " .. SLASH_FIVESECONDRULE1 .. " or " .. SLASH_FIVESECONDRULE2 .. " for settings help.")
+
+SlashCmdList["FIVESECONDRULE"] = function(msg) FiveSecondRule_Cmd:Handle(msg) end
+
+function FiveSecondRule_Cmd:Handle(msg)
+    args = self:SplitByWhitespace(msg)
+    if args then
+        arg = self:NextArg(args)
+        if arg == "stats" then
+            self:HandleStatsCmd(args)
+        elseif arg == "color" then
+            self:HandleColorCmd(args)
+        elseif arg == "reset" then
+            self:ResetSettings()
+        else
+            self:PrintHelp("fsr")
+        end
+    else
+        self:PrintHelp("info")
+    end
+end
+
+function FiveSecondRule_Cmd:HandleStatsCmd(args)
+    local base, effective, posBuff, negBuff = UnitStat("player", 5)
+    DEFAULT_CHAT_FRAME:AddMessage("Spirit - Base: " .. base .. ", Effective: " .. effective .. ", +Buff: " .. posBuff .. ", -Buff: " .. negBuff)
+end
+
+function FiveSecondRule_Cmd:HandleColorCmd(args)
+    local arg = self:NextArg(args)
+    if arg and (arg == "manaloss" or arg == "managain") then
+        local color = self:NextArg(args)
+        if self:IsValidHexColor(color) then
+            if arg == "manaloss" then
+                self:ChangeSettings("manaLossColor", color)
+            else
+                self:ChangeSettings("manaGainColor", color)
+            end
+        else
+            self:PrintHelp("color_hex_format")
+        end
+    else
+        self:PrintHelp("color")
+    end
+end
+
+function FiveSecondRule_Cmd:SplitByWhitespace(str)
+    local words = {}
+    for word in string.gfind(str, "%S+") do
+        table.insert(words, word)
+    end
+    if table.getn(words) > 0 then return words else return nil end
+end
+
+function FiveSecondRule_Cmd:NextArg(args)
+    if table.getn(args) == 0 then return nil end
+    local arg = args[1]
+    for i = 1, table.getn(args) - 1 do
+       args[i] = args[i + 1]
+    end
+    args[table.getn(args)] = nil  -- remove duplicate last element
+    return arg
+end
+
+function FiveSecondRule_Cmd:IsValidHexColor(color)
+    return type(color) == "string" and string.find(string.lower(color), "^%x%x%x%x%x%x$") ~= nil
+end
+
+function FiveSecondRule_Cmd:ChangeSettings(name, value)
+    DEFAULT_CHAT_FRAME:AddMessage(FiveSecondRule_AddonName .. ": Changed '" .. name .. "' from " .. FiveSecondRule_Settings[name] .. " to " .. value)
+    FiveSecondRule_Settings[name] = value
+end
+
+function FiveSecondRule_Cmd:ResetSettings()
+    FiveSecondRule_Settings = FiveSecondRule_Utils:ShallowCopy(FiveSecondRule_Defaults)
+    DEFAULT_CHAT_FRAME:AddMessage(FiveSecondRule_AddonName .. ": Default settings restored.")
+end
+
+function FiveSecondRule_Cmd:PrintHelp(topic)
+    if topic == "info" then
+        DEFAULT_CHAT_FRAME:AddMessage(FiveSecondRule_AddonName .. ": Addon for five-second rule (FSR), mana tick (MP5), and mana gain tracking.")
+        DEFAULT_CHAT_FRAME:AddMessage("Available commands:")
+        DEFAULT_CHAT_FRAME:AddMessage("    /fsr stats -- print character spirit info")
+        DEFAULT_CHAT_FRAME:AddMessage("    /fsr color <manaloss|managain> |cffdd2222RR|r|cff22dd22GG|r|cff2222ddBB|r -- change mana loss/gain text color (color in hex format)")
+        DEFAULT_CHAT_FRAME:AddMessage("    /fsr reset -- reset to default settings")
+    elseif topic == "fsr" then
+        DEFAULT_CHAT_FRAME:AddMessage(FiveSecondRule_AddonName .. ": |cffdd2222Invalid command.")
+        DEFAULT_CHAT_FRAME:AddMessage("Correct syntax:")
+        DEFAULT_CHAT_FRAME:AddMessage("    /fsr stats -- print character spirit info")
+        DEFAULT_CHAT_FRAME:AddMessage("    /fsr color <manaloss|managain> |cffdd2222RR|r|cff22dd22GG|r|cff2222ddBB|r -- change mana loss/gain text color (color in hex format)")
+        DEFAULT_CHAT_FRAME:AddMessage("    /fsr reset -- reset to default settings")
+    elseif topic == "color" then
+        DEFAULT_CHAT_FRAME:AddMessage(FiveSecondRule_AddonName .. ": |cffdd2222Invalid command.")
+        DEFAULT_CHAT_FRAME:AddMessage("Correct syntax:")
+        DEFAULT_CHAT_FRAME:AddMessage("    /fsr color <manaloss|managain> |cffdd2222RR|r|cff22dd22GG|r|cff2222ddBB|r")
+    elseif topic == "color_hex_format" then
+        DEFAULT_CHAT_FRAME:AddMessage(FiveSecondRule_AddonName .. ": |cffdd2222Invalid command.")
+        DEFAULT_CHAT_FRAME:AddMessage("Invalid color hex format or color not specified.")
+        DEFAULT_CHAT_FRAME:AddMessage("Correct syntax:")
+        DEFAULT_CHAT_FRAME:AddMessage("    /fsr color <manaloss|managain> |cffdd2222RR|r|cff22dd22GG|r|cff2222ddBB|r")
+    end
+end

--- a/FiveSecondRule_Cmd.lua
+++ b/FiveSecondRule_Cmd.lua
@@ -19,6 +19,8 @@ function FiveSecondRule_Cmd:Handle(msg)
             self:HandleColorCmd(args)
         elseif arg == "reset" then
             self:ResetSettings()
+        elseif arg == "text" then
+            self:HandleTextCmd(args)
         else
             self:PrintHelp("fsr")
         end
@@ -50,6 +52,15 @@ function FiveSecondRule_Cmd:HandleColorCmd(args)
     end
 end
 
+function FiveSecondRule_Cmd:HandleTextCmd(args)
+    local arg = self:NextArg(args)
+    if arg and (arg == "on" or arg == "off") then
+        self:ChangeSettings("showText", arg == "on")
+    else
+        self:PrintHelp("text")
+    end
+end
+
 function FiveSecondRule_Cmd:SplitByWhitespace(str)
     local words = {}
     for word in string.gfind(str, "%S+") do
@@ -73,7 +84,11 @@ function FiveSecondRule_Cmd:IsValidHexColor(color)
 end
 
 function FiveSecondRule_Cmd:ChangeSettings(name, value)
-    DEFAULT_CHAT_FRAME:AddMessage(FiveSecondRule_AddonName .. ": Changed '" .. name .. "' from " .. FiveSecondRule_Settings[name] .. " to " .. value)
+    if type(value) == "string" then
+        DEFAULT_CHAT_FRAME:AddMessage(FiveSecondRule_AddonName .. ": Changed '" .. name .. "' from " .. FiveSecondRule_Settings[name] .. " to " .. value)
+    elseif type(value) == "boolean" then
+        DEFAULT_CHAT_FRAME:AddMessage(FiveSecondRule_AddonName .. ": '" .. name .. "' " .. (value and "enabled" or "disabled")) -- simulating ternary operator
+    end
     FiveSecondRule_Settings[name] = value
 end
 
@@ -88,12 +103,14 @@ function FiveSecondRule_Cmd:PrintHelp(topic)
         DEFAULT_CHAT_FRAME:AddMessage("Available commands:")
         DEFAULT_CHAT_FRAME:AddMessage("    /fsr stats -- print character spirit info")
         DEFAULT_CHAT_FRAME:AddMessage("    /fsr color <manaloss|managain> |cffdd2222RR|r|cff22dd22GG|r|cff2222ddBB|r -- change mana loss/gain text color (color in hex format)")
+        DEFAULT_CHAT_FRAME:AddMessage("    /fsr text <on|off> -- enable/disable mana change text")
         DEFAULT_CHAT_FRAME:AddMessage("    /fsr reset -- reset to default settings")
     elseif topic == "fsr" then
         DEFAULT_CHAT_FRAME:AddMessage(FiveSecondRule_AddonName .. ": |cffdd2222Invalid command.")
         DEFAULT_CHAT_FRAME:AddMessage("Correct syntax:")
         DEFAULT_CHAT_FRAME:AddMessage("    /fsr stats -- print character spirit info")
         DEFAULT_CHAT_FRAME:AddMessage("    /fsr color <manaloss|managain> |cffdd2222RR|r|cff22dd22GG|r|cff2222ddBB|r -- change mana loss/gain text color (color in hex format)")
+        DEFAULT_CHAT_FRAME:AddMessage("    /fsr text <on|off> -- enable/disable mana change text")
         DEFAULT_CHAT_FRAME:AddMessage("    /fsr reset -- reset to default settings")
     elseif topic == "color" then
         DEFAULT_CHAT_FRAME:AddMessage(FiveSecondRule_AddonName .. ": |cffdd2222Invalid command.")
@@ -104,5 +121,9 @@ function FiveSecondRule_Cmd:PrintHelp(topic)
         DEFAULT_CHAT_FRAME:AddMessage("Invalid color hex format or color not specified.")
         DEFAULT_CHAT_FRAME:AddMessage("Correct syntax:")
         DEFAULT_CHAT_FRAME:AddMessage("    /fsr color <manaloss|managain> |cffdd2222RR|r|cff22dd22GG|r|cff2222ddBB|r")
+    elseif topic == "text" then
+        DEFAULT_CHAT_FRAME:AddMessage(FiveSecondRule_AddonName .. ": |cffdd2222Invalid command.")
+        DEFAULT_CHAT_FRAME:AddMessage("Correct syntax:")
+        DEFAULT_CHAT_FRAME:AddMessage("    /fsr text <on|off>")
     end
 end

--- a/FiveSecondRule_Settings.lua
+++ b/FiveSecondRule_Settings.lua
@@ -1,0 +1,7 @@
+FiveSecondRule_Defaults = {
+    manaLossColor = "800080",
+    manaGainColor = "80A6FF",
+}
+
+-- initialize settings on first AddOn use
+FiveSecondRule_Settings = FiveSecondRule_Utils:ShallowCopy(FiveSecondRule_Defaults)

--- a/FiveSecondRule_Settings.lua
+++ b/FiveSecondRule_Settings.lua
@@ -1,6 +1,7 @@
 FiveSecondRule_Defaults = {
     manaLossColor = "800080",
     manaGainColor = "80A6FF",
+    showText = true,
 }
 
 -- initialize settings on first AddOn use

--- a/FiveSecondRule_Utils.lua
+++ b/FiveSecondRule_Utils.lua
@@ -1,0 +1,8 @@
+FiveSecondRule_Utils = {}
+function FiveSecondRule_Utils:ShallowCopy(orig)
+    local copy = {}
+    for k, v in pairs(orig) do
+        copy[k] = v
+    end
+    return copy
+end


### PR DESCRIPTION
First, thanks for this pretty looking addon. I'm glad this works with old vanilla client.

I appreciate minimalist style of this addon both in code and visually. Although I found it completely not possible to customize by users, which is huge disadvantage in my opinion. So I added some chat commands support. For now implemented text color change, text show on/off toggle, settings reset. Also moved `/stats` debug command to `/fsr stats`.
![command-help-example](https://github.com/user-attachments/assets/92365598-4156-4c97-a013-f2afe76bdb13)

I will try to make changes to this PR, as far as possible and necessary. Maybe later I will add more command in my fork in same branch.